### PR TITLE
bump node-gyp to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "node-addon-api": "^7.0.0",
+    "node-addon-api": "^8.0.0",
     "node-gyp-build": "^4.8.1",
     "prebuildify": "^6.0.1"
   },
@@ -27,7 +27,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": "^10"
   },
   "files": [
     "binding.gyp",


### PR DESCRIPTION
node-gyp<10 isn't compatabile with python 3.12, which doesn't have `distutils` anymore

See https://github.com/nodejs/node-gyp/issues/2869#issuecomment-1966234393